### PR TITLE
Claude Codeの通知をOSC 9で送信し、WezTermで視覚的に通知する

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -244,6 +244,26 @@
           }
         ]
       }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '\\033]9;Claude Code: Waiting for input\\a\\a' > /dev/tty 2>/dev/null"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '\\033]9;Claude Code: Task finished\\a\\a' > /dev/tty 2>/dev/null"
+          }
+        ]
+      }
     ]
   },
   "statusLine": {

--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -94,5 +94,49 @@ config.keys = {
   { key = 'RightArrow', mods = 'CMD', action = wezterm.action.SendString '\x05' }, -- Cmd+Right (行の末尾に移動)
 }
 
+local function is_claude(pane)
+  local process = pane:get_foreground_process_info()
+  if not process or not process.argv then
+    return false
+  end
+  -- Check if any argument contains "claude"
+  for _, arg in ipairs(process.argv) do
+    if arg:find("claude") then
+      return true
+    end
+  end
+  return false
+end
+-- Track tabs with bell for highlighting (Claude Code sends BEL alongside OSC 9)
+local bell_tabs = {}
+wezterm.on("bell", function(window, pane)
+  if is_claude(pane) then
+    local tab = pane:tab()
+    if tab then
+      bell_tabs[tab:tab_id()] = true
+    end
+  end
+end)
+
+wezterm.on("format-tab-title", function(tab)
+	local tab_id = tab.tab_id
+
+	-- Clear bell state when tab becomes active
+	if tab.is_active then
+		bell_tabs[tab_id] = nil
+	end
+
+	-- Highlight tabs with Claude Code notifications
+	if bell_tabs[tab_id] and not tab.is_active then
+		local title = (tab.tab_index + 1) .. ": " .. tab.active_pane.title
+		return {
+			{ Background = { Color = "#e2943b" } },
+			{ Foreground = { Color = "#161821" } },
+			{ Text = " " .. title .. " " },
+		}
+	end
+end)
+config.audible_bell = "Disabled"
+
 -- and finally, return the configuration to wezterm
 return config


### PR DESCRIPTION
## 概要
Claude CodeのNotification/Stopフックで、OSC 9によるデスクトップ通知とBELによるタブハイライトを実装する。

## 変更内容
- Claude Codeの`Notification`フックでOSC 9通知("Waiting for input")を送信
- Claude Codeの`Stop`フックでOSC 9通知("Task finished")を送信
- OSC 9の後にBEL文字を追加し、非対応ターミナルでもフォールバック通知を提供
- WezTermでBEL検知時に非アクティブタブをオレンジ色でハイライト表示
- タブがアクティブになったらハイライトを自動解除
- `audible_bell`を`Disabled`に設定し、音声ベルを無効化

## 設計判断
- **OSC 9**: デスクトップ通知の事実上の標準。WezTerm, Ghostty, Kitty, iTerm2で対応
- **BEL**: タブハイライト用 + OSC 9非対応ターミナル(VS Code, Alacritty等)のフォールバック
- イベントごとにメッセージを出し分け(Notification → 入力待ち / Stop → 処理終了)

## 変更ファイル
- `.config/claude/settings.json`: Notification/Stopフックの追加
- `.config/wezterm/wezterm.lua`: BEL検知によるタブハイライトの実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)